### PR TITLE
Heroku was looking for the wrong .jar file, fixed

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web java $JAVA_OPTS -Dserver.port=$PORT -jar target/microfund-b.jar.original
+web: java -Dserver.port=$PORT $JAVA_OPTS -jar "target/testmicrofund.jar"


### PR DESCRIPTION
In the pom.xml file there is a `<build><finalName>` tag that determines the name of the .jar file heroku looks for when it deploys. For whatever reason, the Procfile was setup to tell it to look for the wrong name.