### PR TITLE
change order of security filters, and lots of little things

### DIFF
--- a/src/main/java/com/lambdaschool/oktafoundation/SeedData.java
+++ b/src/main/java/com/lambdaschool/oktafoundation/SeedData.java
@@ -77,6 +77,11 @@ public class SeedData implements CommandLineRunner
         organization3 = organizationService.save(organization3);
 
 
+        // WE NEED AN OKTA USER SETUP WITH ADMIN RIGHTS
+        User uo = new User("llama001@maildrop.cc");
+        uo.getRoles().add(new UserRoles(uo, r1));
+        userService.save(uo);
+
         // The following is an example user!
         /*
         // admin, data, user
@@ -109,8 +114,12 @@ public class SeedData implements CommandLineRunner
 
         User u2 = new User("coolorg@lambdaschool.local");
         u2.getRoles().add(new UserRoles(u2, r2));
-        Application app1 = new Application("Org 1", "123 somewhere drive", "923-567-8965", "i want to help my community", "not reviewed", organization1, u2);
-        Application app2 = new Application("Org 2", "124 rainbow lane", "444-111-3333", "i have a great idea i need help with", "not reviewed", organization2, u2);
+        Application app1 = new Application("Org 1", "123 somewhere drive", "923-567" +
+            "-8965","partner", "i want to help my community", "not reviewed",
+            organization1, u2);
+        Application app2 = new Application("Org 2", "124 rainbow lane", "444-111-3333",
+            "partner", "i have a great idea i need help with", "not reviewed",
+            organization2, u2);
 
         u2.getApplications().add(app1);
         u2.getApplications().add(app2);
@@ -118,7 +127,9 @@ public class SeedData implements CommandLineRunner
 
         User u3 = new User("evencoolerorg@lambdaschool.local");
         u3.getRoles().add(new UserRoles(u3, r3));
-        Application app3 = new Application("Org 3", "534 abbey road", "000-345-9807", "i would love to be a part of this", "not reviewed", organization3, u3);
+        Application app3 = new Application("Org 3", "534 abbey road", "000-345-9807",
+            "partner", "i would love to be a part of this", "not reviewed", organization3,
+            u3);
 
         u3.getApplications().add(app3);
         u3.addOrganization(organization3);

--- a/src/main/java/com/lambdaschool/oktafoundation/config/OktaAuthSecurityConfig.java
+++ b/src/main/java/com/lambdaschool/oktafoundation/config/OktaAuthSecurityConfig.java
@@ -4,15 +4,14 @@ import com.okta.spring.boot.oauth.Okta;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.web.access.intercept.FilterSecurityInterceptor;
 
-@Configuration
-@EnableWebSecurity
+// This allows us to further restrict access to an endpoint inside of a controller.
 @EnableGlobalMethodSecurity(prePostEnabled = true)
+@Configuration
 public class OktaAuthSecurityConfig extends WebSecurityConfigurerAdapter
 {
     @Bean
@@ -21,9 +20,6 @@ public class OktaAuthSecurityConfig extends WebSecurityConfigurerAdapter
     {
         return new JwtAuthenticationFilter();
     }
-
-
-
 
     @Override
     protected void configure(HttpSecurity http) throws Exception
@@ -35,8 +31,7 @@ public class OktaAuthSecurityConfig extends WebSecurityConfigurerAdapter
                 "/swagger-resource/**",
                 "/swagger-ui.html",
                 "/v2/api-docs",
-                "/webjars/**",
-                "/createnewuser")
+                "/webjars/**")
             .permitAll()
             .antMatchers(HttpMethod.POST,
                 "/users/**")
@@ -48,19 +43,16 @@ public class OktaAuthSecurityConfig extends WebSecurityConfigurerAdapter
                 "/users/**")
             .hasAnyRole("ADMIN")
 
-            // *** NOTE EVERYONE CAN READ USERS!!!
+            // *** NOTE AUTHENTICATED CAN READ USERS!!! PATCHES are handled in UserService
             .antMatchers("/users/**")
-            .permitAll()
-            // .authenticated()
-            // *** NOTE EVERYONE CAN READ USERS!!!
-
-            .antMatchers(
-                "/useremails/**",
-                "/oauth/revoke-token",
-                "/logout")
+            .authenticated()
+            // *** Handled at UseremailService Level
+            .antMatchers("/useremails/**")
             .authenticated()
             .antMatchers("/roles/**")
             .hasAnyRole("ADMIN")
+            // *** Endpoints not specified above are automatically denied
+            .anyRequest().denyAll()
             .and()
             .exceptionHandling()
             .and()
@@ -77,6 +69,12 @@ public class OktaAuthSecurityConfig extends WebSecurityConfigurerAdapter
             .csrf()
             .disable();
 
+        // Insert the JwtAuthenticationFilter so that it can grab credentials from the
+        // local database before they are checked for authorization
+        http
+            .addFilterBefore(authenticationTokenFilterBean(),
+                FilterSecurityInterceptor.class);
+
         // force a non-empty response body for 401's to make the response more browser friendly
         Okta.configureResourceServer401ResponseBody(http);
 
@@ -85,5 +83,4 @@ public class OktaAuthSecurityConfig extends WebSecurityConfigurerAdapter
             .frameOptions()
             .disable();
     }
-
 }

--- a/src/main/java/com/lambdaschool/oktafoundation/models/User.java
+++ b/src/main/java/com/lambdaschool/oktafoundation/models/User.java
@@ -49,7 +49,8 @@ public class User extends Auditable
      * Part of the join relationship between user and role
      * connects users to the user role combination
      */
-    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(fetch = FetchType.EAGER, mappedBy = "user", cascade = CascadeType.ALL,
+        orphanRemoval = true)
     @JsonIgnoreProperties(value = "user", allowSetters = true)
     private Set<UserRoles> roles = new HashSet<>();
 

--- a/src/main/java/com/lambdaschool/oktafoundation/services/OrganizationServiceImpl.java
+++ b/src/main/java/com/lambdaschool/oktafoundation/services/OrganizationServiceImpl.java
@@ -77,7 +77,9 @@ public class OrganizationServiceImpl implements OrganizationService
         for (Application ap : organization.getApplications())
         {
             newOrg.getApplications().add(new Application(ap.getName(),
-                ap.getAddress(), ap.getPhone(),
+                ap.getAddress(),
+                ap.getPhone(),
+                ap.getType(),
                 ap.getReason(),
                 ap.getStatus(), newOrg,
                 ap.getUser()));
@@ -128,7 +130,9 @@ public class OrganizationServiceImpl implements OrganizationService
 //                                ap.getStatus()));
 
                 currentOrg.getApplications().add(new Application(ap.getName(),
-                    ap.getAddress(), ap.getPhone(),
+                    ap.getAddress(),
+                    ap.getPhone(),
+                    ap.getType(),
                     ap.getReason(),
                     ap.getStatus(), currentOrg,
                     ap.getUser()));

--- a/src/main/java/com/lambdaschool/oktafoundation/services/UserServiceImpl.java
+++ b/src/main/java/com/lambdaschool/oktafoundation/services/UserServiceImpl.java
@@ -154,9 +154,12 @@ public class UserServiceImpl implements UserService
 //                            ap.getReason(),
 //                            ap.getStatus()));
             newUser.getApplications().add(new Application(ap.getName(),
-                ap.getAddress(), ap.getPhone(),
+                ap.getAddress(),
+                ap.getPhone(),
+                ap.getType(),
                 ap.getReason(),
-                ap.getStatus(), ap.getOrganization(),
+                ap.getStatus(),
+                ap.getOrganization(),
                 newUser));
         }
 
@@ -266,7 +269,9 @@ public class UserServiceImpl implements UserService
 //                                    ap.getReason(),
 //                                    ap.getStatus()));
                     currentUser.getApplications().add(new Application(ap.getName(),
-                        ap.getAddress(), ap.getPhone(),
+                        ap.getAddress(),
+                        ap.getPhone(),
+                        ap.getType(),
                         ap.getReason(),
                         ap.getStatus(), ap.getOrganization(),
                         currentUser));


### PR DESCRIPTION
### Description
Made a bunch of minor changes to the seed data, and a couple services. This was necessary to run locally and test. Without these changes the seed data wouldn't load.

The big changes are in JwtAuthenticationFilter and OktaAuthSecurityConfig These allow for authorization to work properly. Credit goes to John for figuring out most of this. There's also an important related change in the User model. adding `fetch = FetchType.EAGER`

WIth this, testing locally should be much easier now, and authorization will now work.

### Trello Link
[Backend doesn't have proper authorization](https://trello.com/c/D7VA1z0A/23-0-backend-doesnt-have-proper-authorization)

### Type of Change
- [X] Bug Fix
- [X] Breaking Change